### PR TITLE
overwrite cy.visit to remove service worker

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -202,6 +202,14 @@ Cypress.Commands.add("confirmItem", (itemName, page_name) => {
   cy.contains("td", itemName).should("be.visible");
 });
 
+Cypress.Commands.overwrite("visit", (cyVisit, url) => {
+  cyVisit(url, {
+    onBeforeLoad(win) {
+      delete win.navigator.__proto__.serviceWorker;
+    }
+  });
+});
+
 //an alternative to userLoginSetup - currently configured for app 200
 Cypress.Commands.add("login", () => {
   const loginPage = "/f?p=200:LOGIN";

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -7,4 +7,4 @@ import "@percy/cypress";
  * https://github.com/bahmutov/cypress-failed-log
  */
 import "cypress-failed-log";
-import './commands'
+import "./commands";


### PR DESCRIPTION
Trying to figure out if caching in the service worker leads to flaky redirects

Still seeing weird behavior - sometimes service worker is disabled, sometimes not (iframes?) and seeing bunch of errors in the console

<img width="1274" alt="Screen Shot 2019-12-12 at 10 54 01 PM" src="https://user-images.githubusercontent.com/2212006/70768305-8da20f80-1d32-11ea-8efa-42b579462e6c.png">
