### PR TITLE
fix: login toast msg check

### DIFF
--- a/cypress/integration/app/app200.0.login.js
+++ b/cypress/integration/app/app200.0.login.js
@@ -64,6 +64,14 @@ context("App 200 login test", () => {
           console.log("url before sign in", url);
         });
       cy.getCy("sign_inButton").click();
+      // the user can close the login error alert
+      cy.get(".mdc-snackbar--open")
+        .should("be.visible")
+        .should("contain.text", "Invalid Login")
+        .find('button.e-Notification--close.mdc-icon-button')
+        .click();
+      // the login error disappears when users clicked the close button
+      cy.get(".mdc-snackbar--open").should("not.exist");
       //cy.wait("@login");
 
       // the url changes
@@ -76,8 +84,6 @@ context("App 200 login test", () => {
       //  // and instead is sends error message id
       //  .and("include", "notification_msg");
       //
-      // the user can close the login error alert
-      cy.contains(".mdc-snackbar__label", "Invalid Login").should("be.visible");
     });
   });
 


### PR DESCRIPTION
I tried to fix few things from [failing tests ](https://app.circleci.com/pipelines/github/forallabeautifulearth/fabe-browser-tests/564/workflows/7867b3ea-3d57-4e1a-8c11-e0d3efa7d86e/jobs/702)
- fixed the toast message visibility check
- added click action to hide the toast message 